### PR TITLE
All `SocketType` conformances have been updated.

### DIFF
--- a/Sources/Quaternion/Context/Execution.swift
+++ b/Sources/Quaternion/Context/Execution.swift
@@ -18,7 +18,7 @@ public struct ExecutionParameters {
 
     func getInputValue<T>(named name: String) throws -> T {
         let socket = try node.getInputSocket(named: name)
-        let value = socket.type.value.actualValue()
+        let value = try socket.type.readValue().actualValue()
 
         guard let typedValue = value as? T else {
             throw SocketError.castingError(from: value.self, to: T.self)

--- a/Sources/Quaternion/Tree/Tree.swift
+++ b/Sources/Quaternion/Tree/Tree.swift
@@ -121,7 +121,7 @@ extension Tree {
             for socketId in outputSocket.connectedTo {
                 try nodes[parentNode[socketId]!]!.inputSockets[socketId]!.type
                     .setValue(
-                        to: outputSocket.type.value
+                        to: outputSocket.type.readValue()
                     )
             }
         }

--- a/Sources/Quaternion/Types/Socket Types/NumericSocket.swift
+++ b/Sources/Quaternion/Types/Socket Types/NumericSocket.swift
@@ -8,22 +8,33 @@
 import Foundation
 
 public struct NumericSocket: SocketType {
-    public var value: SocketValueType = .numeric(0)
 
+    public var defaultValue: SocketValueType = .numeric(0)
+    public var currentValue: SocketValueType
+    
     init(defaultValue: SocketValueType) {
-        value = defaultValue
+        currentValue = defaultValue
     }
 
     init() {
-
+        currentValue = defaultValue
     }
 
     public mutating func setValue(to newValue: SocketValueType) throws {
-        value = newValue
+        currentValue = newValue
     }
 
     public func readValue() throws -> SocketValueType {
-        value
+        currentValue
     }
 
+    
+    public mutating func setToDefaultValue() {
+        currentValue = defaultValue
+    }
+    
+    public func readDefaultValue() -> SocketValueType {
+        defaultValue
+    }
+    
 }


### PR DESCRIPTION
This pull request also fixes some errors that arose when deleting the `value` property from `SocketType`. 