### PR TITLE
Feature/ham 56 modify tree to be a reference type

### DIFF
--- a/Sources/Quaternion/Node/Node.swift
+++ b/Sources/Quaternion/Node/Node.swift
@@ -6,14 +6,12 @@ import Foundation
 public struct Node: Identifiable {
 
     public var id: UUID = UUID()
-    public var name: String
     public var inputSockets: [UUID: InputSocket] = [:]
     public var outputSockets: [UUID: OutputSocket] = [:]
 
     public var type: any NodeType
 
-    init(named name: String, ofType type: any NodeType) {
-        self.name = name
+    init(ofType type: any NodeType) {
         self.type = type
 
         var parametersBuilder = ParametersBuilder()

--- a/Sources/Quaternion/Tree/Tree.swift
+++ b/Sources/Quaternion/Tree/Tree.swift
@@ -17,8 +17,8 @@ struct Tree {
     var orderedNodes: [NodeID] = []
     var parentNode: [SocketID: NodeID] = [:]
 
-    mutating func addNode(named name: String, ofType type: NodeType) -> UUID {
-        let newNode = Node(named: name, ofType: type)
+    mutating func addNode(ofType type: NodeType) -> UUID {
+        let newNode = Node(ofType: type)
         nodes.updateValue(newNode, forKey: newNode.id)
 
         // Update parent node pointers

--- a/Sources/Quaternion/Tree/Tree.swift
+++ b/Sources/Quaternion/Tree/Tree.swift
@@ -10,14 +10,19 @@ import Foundation
 typealias SocketID = UUID
 typealias NodeID = UUID
 
-struct Tree {
+@Observable
+class Tree {
     var id: UUID = UUID()
     var name: String
-    var nodes: [NodeID: Node] = [:]
-    var orderedNodes: [NodeID] = []
-    var parentNode: [SocketID: NodeID] = [:]
+    private(set) var nodes: [NodeID: Node] = [:]
+    private(set) var orderedNodes: [NodeID] = []
+    private var parentNode: [SocketID: NodeID] = [:]
+    
+    init(name: String) {
+        self.name = name
+    }
 
-    mutating func addNode(ofType type: NodeType) -> UUID {
+    func addNode(ofType type: NodeType) -> UUID {
         let newNode = Node(ofType: type)
         nodes.updateValue(newNode, forKey: newNode.id)
 
@@ -46,7 +51,7 @@ extension Tree {
 
 extension Tree {
     /// Topologically sorts the tree nodes.
-    mutating private func computeExecutionOrder() {
+    private func computeExecutionOrder() {
 
         // TODO: Implement ordering caching.
 
@@ -81,7 +86,7 @@ extension Tree {
 }
 
 extension Tree {
-    mutating func propagateValues(for node: Node) throws {
+    func propagateValues(for node: Node) throws {
         for outputSocket in node.outputSockets.values {
             for socketId in outputSocket.connectedTo {
                 try nodes[parentNode[socketId]!]!.inputSockets[socketId]!.type
@@ -94,7 +99,7 @@ extension Tree {
 }
 
 extension Tree {
-    mutating func execute() throws {
+    func execute() throws {
         computeExecutionOrder()
 
         for nodeID in orderedNodes {
@@ -107,7 +112,7 @@ extension Tree {
 }
 
 extension Tree {
-    mutating func setSocketValue(
+    func setSocketValue(
         forNode nodeID: UUID,
         atSocket socketID: UUID,
         to value: SocketValueType
@@ -131,7 +136,7 @@ extension Tree {
         }
     }
 
-    mutating func setSocketDefaultValue(
+    func setSocketDefaultValue(
         forNode nodeID: UUID,
         atSocket socketID: UUID,
         to value: SocketValueType
@@ -146,7 +151,7 @@ extension Tree {
         }
     }
 
-    mutating func resetSocketValueToDefault(
+    func resetSocketValueToDefault(
         forNode nodeID: UUID,
         atSocket socketID: UUID
     ) throws {
@@ -165,7 +170,7 @@ extension Tree {
     ///
     ///  This function does not propagate any values. Value propagation is defered until `NodeTree::execute()`
     ///  is called.
-    mutating func connect(
+    func connect(
         from: UUID,
         atSocket sourceSocketName: String,
         to: UUID,
@@ -196,7 +201,7 @@ extension Tree {
     }
 
     /// This function disconnects an input socket
-    mutating func disconnect(node nodeID: UUID, inputSocket socketID: UUID)
+    func disconnect(node nodeID: UUID, inputSocket socketID: UUID)
         throws
     {
         // Check that node exists.
@@ -215,7 +220,7 @@ extension Tree {
         }
     }
 
-    mutating func disconnect(
+    func disconnect(
         node nodeID: UUID,
         outputSocket socketID: UUID,
         fromSocket targetID: UUID

--- a/Sources/Quaternion/Types/Node Types/ConstantNode.swift
+++ b/Sources/Quaternion/Types/Node Types/ConstantNode.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-struct ConstantNode: NodeType {
+class ConstantNode: NodeType {
     func execute(params p: inout ExecutionParameters) throws {
     }
 

--- a/Sources/Quaternion/Types/Node Types/MathNode.swift
+++ b/Sources/Quaternion/Types/Node Types/MathNode.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-struct MathNode: NodeType {
+class MathNode: NodeType {
     func execute(params p: inout ExecutionParameters) throws {
         let lhs: Float = try p.getInputValue(named: "LHS")
         let rhs: Float = try p.getInputValue(named: "RHS")

--- a/Tests/QuaternionTests/ConnectionTests.swift
+++ b/Tests/QuaternionTests/ConnectionTests.swift
@@ -13,8 +13,8 @@ import Testing
 @Test func defaultValuesTest() async throws {
     var tree = Tree(name: "2+2=4")
     // TODO: Notice that name is irrelevant for nodes.
-    let lhs = tree.addNode(named: "Constant", ofType: ConstantNode())
-    let rhs = tree.addNode(named: "Constant", ofType: ConstantNode())
+    let lhs = tree.addNode(ofType: ConstantNode())
+    let rhs = tree.addNode(ofType: ConstantNode())
 
     let socketLHS = try tree.findNodeById(id: lhs).getOutputSocket(
         named: "Value"
@@ -35,7 +35,7 @@ import Testing
         to: .numeric(2)
     )
 
-    let op = tree.addNode(named: "Sum", ofType: MathNode())
+    let op = tree.addNode(ofType: MathNode())
 
     try tree.connect(from: lhs, atSocket: "Value", to: op, atSocket: "LHS")
     try tree.connect(from: rhs, atSocket: "Value", to: op, atSocket: "RHS")
@@ -52,8 +52,8 @@ import Testing
 @Test func setCurrentValueTest() async throws {
     var tree = Tree(name: "2+2=4")
     // TODO: Notice that name is irrelevant for nodes.
-    let lhs = tree.addNode(named: "Constant", ofType: ConstantNode())
-    let rhs = tree.addNode(named: "Constant", ofType: ConstantNode())
+    let lhs = tree.addNode(ofType: ConstantNode())
+    let rhs = tree.addNode(ofType: ConstantNode())
 
     let socketLHS = try tree.findNodeById(id: lhs).getOutputSocket(
         named: "Value"
@@ -74,7 +74,7 @@ import Testing
         to: .numeric(2)
     )
 
-    let op = tree.addNode(named: "Sum", ofType: MathNode())
+    let op = tree.addNode(ofType: MathNode())
 
     try tree.connect(from: lhs, atSocket: "Value", to: op, atSocket: "LHS")
     try tree.connect(from: rhs, atSocket: "Value", to: op, atSocket: "RHS")
@@ -90,8 +90,8 @@ import Testing
 @Test func disconnectionTest() async throws {
     var tree = Tree(name: "2+1=3")
     // TODO: Notice that name is irrelevant for nodes.
-    let lhs = tree.addNode(named: "Constant", ofType: ConstantNode())
-    let rhs = tree.addNode(named: "Constant", ofType: ConstantNode())
+    let lhs = tree.addNode(ofType: ConstantNode())
+    let rhs = tree.addNode(ofType: ConstantNode())
 
     let socketLHS = try tree.findNodeById(id: lhs).getOutputSocket(
         named: "Value"
@@ -112,7 +112,7 @@ import Testing
         to: .numeric(2)
     )
 
-    let op = tree.addNode(named: "Sum", ofType: MathNode())
+    let op = tree.addNode(ofType: MathNode())
 
     try tree.connect(from: lhs, atSocket: "Value", to: op, atSocket: "LHS")
     try tree.connect(from: rhs, atSocket: "Value", to: op, atSocket: "RHS")
@@ -124,17 +124,17 @@ import Testing
 
     #expect(result == .numeric(4.0))
 
-    let lhs1 = tree.addNode(named: "Constant", ofType: ConstantNode())
+    let lhs1 = tree.addNode(ofType: ConstantNode())
     let mathLHS = try tree.findNodeById(id: op).getInputSocket(named: "LHS").id
 
     try tree.disconnect(node: lhs, outputSocket: socketLHS, fromSocket: mathLHS)
 
     try tree.connect(from: lhs1, atSocket: "Value", to: op, atSocket: "LHS")
-    
+
     try tree.execute()
-    
+
     let opNode1 = try tree.findNodeById(id: op)
     let result1 = try opNode1.getOutputSocket(named: "Result").type.readValue()
-    
+
     #expect(result1 == .numeric(3.0))
 }

--- a/Tests/QuaternionTests/QuaternionTests.swift
+++ b/Tests/QuaternionTests/QuaternionTests.swift
@@ -5,16 +5,14 @@ import Testing
 @Test func onePlusOneTest() async throws {
     var tree = Tree(name: "Test")
     let lhs = tree.addNode(
-        named: "Constant",
         ofType: ConstantNode()
     )
 
     let rhs = tree.addNode(
-        named: "Constant 2",
         ofType: ConstantNode()
     )
 
-    let op = tree.addNode(named: "Sum", ofType: MathNode())
+    let op = tree.addNode(ofType: MathNode())
 
     try tree.connect(from: lhs, atSocket: "Value", to: op, atSocket: "LHS")
     try tree.connect(from: rhs, atSocket: "Value", to: op, atSocket: "RHS")
@@ -32,11 +30,10 @@ import Testing
     var tree = Tree(name: "Testing tree")
 
     let lhs = tree.addNode(
-        named: "Constant",
         ofType: ConstantNode()
     )
 
-    let op = tree.addNode(named: "Sum", ofType: MathNode())
+    let op = tree.addNode(ofType: MathNode())
 
     try tree.connect(from: lhs, atSocket: "Value", to: op, atSocket: "LHS")
 
@@ -50,26 +47,23 @@ import Testing
     var tree = Tree(name: "Arithmetic tree")
 
     let lhs = tree.addNode(
-        named: "Constant",
         ofType: ConstantNode()
     )
 
     let rhs = tree.addNode(
-        named: "Constant",
         ofType: ConstantNode()
     )
 
-    let op = tree.addNode(named: "Operation", ofType: MathNode())
+    let op = tree.addNode(ofType: MathNode())
 
     try tree.connect(from: lhs, atSocket: "Value", to: op, atSocket: "LHS")
     try tree.connect(from: rhs, atSocket: "Value", to: op, atSocket: "RHS")
 
     let rhs2 = tree.addNode(
-        named: "Constant",
         ofType: ConstantNode()
     )
 
-    let op2 = tree.addNode(named: "Operation 2", ofType: MathNode())
+    let op2 = tree.addNode(ofType: MathNode())
 
     try tree.connect(from: op, atSocket: "Result", to: op2, atSocket: "LHS")
     try tree.connect(


### PR DESCRIPTION
This improves performance by avoiding copies in each `Tree` mutation. Also, `NodeType` implementations are now reference types.