### PR TITLE
Metadata implementation

### DIFF
--- a/Sources/Quaternion/Context/Execution.swift
+++ b/Sources/Quaternion/Context/Execution.swift
@@ -12,6 +12,7 @@ public struct ExecutionParameters {
 
     var node: Node
 
+    // TODO: This does not need to be inout.
     init(node: inout Node) {
         self.node = node
     }

--- a/Sources/Quaternion/Node/Node.swift
+++ b/Sources/Quaternion/Node/Node.swift
@@ -7,6 +7,7 @@ public struct Node: Identifiable {
     public var outputSockets: [UUID: OutputSocket] = [:]
 
     public var type: any NodeType
+    public var metadata: (any NodeMetadata)? 
 
     init(ofType type: any NodeType) {
         self.type = type

--- a/Sources/Quaternion/Node/Node.swift
+++ b/Sources/Quaternion/Node/Node.swift
@@ -1,6 +1,3 @@
-// The Swift Programming Language
-// https://docs.swift.org/swift-book
-
 import Foundation
 
 public struct Node: Identifiable {

--- a/Sources/Quaternion/Node/Node.swift
+++ b/Sources/Quaternion/Node/Node.swift
@@ -7,7 +7,7 @@ public struct Node: Identifiable {
     public var outputSockets: [UUID: OutputSocket] = [:]
 
     public var type: any NodeType
-    public var metadata: (any NodeMetadata)? 
+    public var metadata: (any NodeMetadata)?
 
     init(ofType type: any NodeType) {
         self.type = type
@@ -18,6 +18,8 @@ public struct Node: Identifiable {
 
         (inputSockets, outputSockets) =
             parametersBuilder.parameters
+        
+        metadata = CoreMetadata()
     }
 }
 

--- a/Sources/Quaternion/Node/NodeMetadata.swift
+++ b/Sources/Quaternion/Node/NodeMetadata.swift
@@ -6,7 +6,5 @@
 //
 
 public protocol NodeMetadata {
-    var displayName: String { get }
-    var description: String { get }
-    var tags: Set<String> { get }
+    // TODO...
 }

--- a/Sources/Quaternion/Node/NodeMetadata.swift
+++ b/Sources/Quaternion/Node/NodeMetadata.swift
@@ -9,3 +9,8 @@
 public protocol NodeMetadata {
     // TODO...
 }
+
+public class CoreMetadata: NodeMetadata {
+    var isSelected: Bool = false
+    var position: SIMD3<Float> = .zero
+}

--- a/Sources/Quaternion/Node/NodeMetadata.swift
+++ b/Sources/Quaternion/Node/NodeMetadata.swift
@@ -1,0 +1,12 @@
+//
+//  NodeMetadata.swift
+//  Quaternion
+//
+//  Created by Milton Montiel on 22/07/25.
+//
+
+public protocol NodeMetadata {
+    var displayName: String { get }
+    var desciption: String { get }
+    var tags: Set<String> { get }
+}

--- a/Sources/Quaternion/Node/NodeMetadata.swift
+++ b/Sources/Quaternion/Node/NodeMetadata.swift
@@ -5,6 +5,7 @@
 //  Created by Milton Montiel on 22/07/25.
 //
 
+/// This is metadata owned by an instance of a node.
 public protocol NodeMetadata {
     // TODO...
 }

--- a/Sources/Quaternion/Node/NodeMetadata.swift
+++ b/Sources/Quaternion/Node/NodeMetadata.swift
@@ -7,6 +7,6 @@
 
 public protocol NodeMetadata {
     var displayName: String { get }
-    var desciption: String { get }
+    var description: String { get }
     var tags: Set<String> { get }
 }

--- a/Sources/Quaternion/Node/NodeType.swift
+++ b/Sources/Quaternion/Node/NodeType.swift
@@ -8,6 +8,8 @@
 import Foundation
 
 public protocol NodeType {
+    var metadata: NodeTypeMetadata { get }
+
     func declareNode(params b: inout ParametersBuilder)
 
     func execute(params p: inout ExecutionParameters) throws

--- a/Sources/Quaternion/Node/NodeType.swift
+++ b/Sources/Quaternion/Node/NodeType.swift
@@ -1,5 +1,5 @@
 //
-//  File.swift
+//  NodeType.swift
 //  Quaternion
 //
 //  Created by Milton Montiel on 16/07/25.

--- a/Sources/Quaternion/Node/NodeType.swift
+++ b/Sources/Quaternion/Node/NodeType.swift
@@ -8,7 +8,7 @@
 import Foundation
 
 public protocol NodeType {
-    var metadata: NodeTypeMetadata { get }
+    var metadata: any NodeTypeMetadata { get }
 
     func declareNode(params b: inout ParametersBuilder)
 

--- a/Sources/Quaternion/Node/NodeTypeMetadata.swift
+++ b/Sources/Quaternion/Node/NodeTypeMetadata.swift
@@ -5,8 +5,15 @@
 //  Created by Milton Montiel on 24/07/25.
 //
 
-public struct NodeTypeMetadata {
-    var name: String
-    var description: String
-    var tags: Set<String>
+/// This specifies the metadata shared by all nodes of a given type.
+public protocol NodeTypeMetadata {
+    var name: String { get }
+    var description: String { get }
+    var tags: Set<String> { get }
+}
+
+public struct TypeMetadata: NodeTypeMetadata {
+    public let name: String
+    public let description: String
+    public let tags: Set<String>
 }

--- a/Sources/Quaternion/Node/NodeTypeMetadata.swift
+++ b/Sources/Quaternion/Node/NodeTypeMetadata.swift
@@ -1,0 +1,12 @@
+//
+//  NodeTypeMetadata.swift
+//  Quaternion
+//
+//  Created by Milton Montiel on 24/07/25.
+//
+
+public struct NodeTypeMetadata {
+    var name: String
+    var description: String
+    var tags: Set<String>
+}

--- a/Sources/Quaternion/Types/Node Types/ConstantNode.swift
+++ b/Sources/Quaternion/Types/Node Types/ConstantNode.swift
@@ -8,6 +8,12 @@
 import Foundation
 
 class ConstantNode: NodeType {
+    var metadata = NodeTypeMetadata(
+        name: "Constant Node",
+        description: "Returns a constant numeric value",
+        tags: ["Constant", "Numeric", "Math"]
+    )
+
     func execute(params p: inout ExecutionParameters) throws {
     }
 

--- a/Sources/Quaternion/Types/Node Types/ConstantNode.swift
+++ b/Sources/Quaternion/Types/Node Types/ConstantNode.swift
@@ -8,7 +8,7 @@
 import Foundation
 
 class ConstantNode: NodeType {
-    var metadata = NodeTypeMetadata(
+    var metadata: any NodeTypeMetadata = TypeMetadata(
         name: "Constant Node",
         description: "Returns a constant numeric value",
         tags: ["Constant", "Numeric", "Math"]

--- a/Sources/Quaternion/Types/Node Types/MathNode.swift
+++ b/Sources/Quaternion/Types/Node Types/MathNode.swift
@@ -8,6 +8,13 @@
 import Foundation
 
 class MathNode: NodeType {
+    var metadata = NodeTypeMetadata(
+        name: "Math Node",
+        description:
+            "This node performs basic arithmetic operations on two numeric inputs.",
+        tags: ["Math", "Arithmetic", "Numeric"]
+    )
+
     func execute(params p: inout ExecutionParameters) throws {
         let lhs: Float = try p.getInputValue(named: "LHS")
         let rhs: Float = try p.getInputValue(named: "RHS")

--- a/Sources/Quaternion/Types/Node Types/MathNode.swift
+++ b/Sources/Quaternion/Types/Node Types/MathNode.swift
@@ -8,7 +8,7 @@
 import Foundation
 
 class MathNode: NodeType {
-    var metadata = NodeTypeMetadata(
+    var metadata: any NodeTypeMetadata = TypeMetadata(
         name: "Math Node",
         description:
             "This node performs basic arithmetic operations on two numeric inputs.",


### PR DESCRIPTION
This pull request implements two forms of metadata: 

- `NodeTypeMetadata`: This is metadata shared by all nodes of a common type. 
- `NodeMetadata`: This is owned by concrete node instances. 

A simple example of the usage is given but it can be improved by writing proper documentation.